### PR TITLE
Ignore node_modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 wpp-research/
 .wp-env.override.json
+node_modules/


### PR DESCRIPTION
@swissspidy I assume you have a global `.gitignore` that ignores `node_modules`? I think it's worth ignoring it here regardless so that that's the case for anyone using this repository (covering both the root level `node_modules` as well as those in the `new` and `old` directories).