### PR TITLE
Add support for formatting output as CSV and sending to files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 wpp-research/
 .wp-env.override.json
-node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 wpp-research/
 .wp-env.override.json
+node_modules/

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ this repository provides a [GitHub Action](https://github.com/features/actions) 
 Run the following command in the terminal:
 
 ```shell
-./run.sh [old=latest] [new=trunk] [skip_init=false]
+./run.sh [old=latest] [new=trunk] [skip_init=false] [output=markdown] [skip_formatting=false]
 ```
 
 By default, it compares the latest stable release with the current trunk version. So `./run.sh` is the same as `./run.sh latest trunk`.
@@ -34,6 +34,12 @@ To test a specific WP version by ZIP file:
 
 ```shell
 ./run.sh latest https://wordpress.org/wordpress-6.3-RC2.zip
+```
+
+The default output is as Markdown tables. To get output data as CSV without formatted numbers:
+
+```shell
+./run.sh latest trunk false csv true
 ```
 
 ### GitHub Actions

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ this repository provides a [GitHub Action](https://github.com/features/actions) 
 Run the following command in the terminal:
 
 ```shell
-./run.sh [old=latest] [new=trunk] [skip_init=false] [output=markdown] [skip_formatting=false]
+./run.sh [old=latest] [new=trunk] [skip_init=false] [output=markdown] [skip_formatting=false] [print_to_files=false]
 ```
 
 By default, it compares the latest stable release with the current trunk version. So `./run.sh` is the same as `./run.sh latest trunk`.
@@ -41,6 +41,14 @@ The default output is as Markdown tables. To get output data as CSV without form
 ```shell
 ./run.sh latest trunk false csv true
 ```
+
+To pipe that output into (CSV) files:
+
+```shell
+./run.sh latest trunk false csv true true
+```
+
+This will result in four CSV files with the individual table results.
 
 ### GitHub Actions
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 			"name": "@swissspidy/compare-wp-performance",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"csv-stringify": "^6.4.0",
 				"csvtojson": "^2.0.10",
 				"tablemark": "^3.0.0"
 			},
@@ -6252,6 +6253,11 @@
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
 			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
 			"dev": true
+		},
+		"node_modules/csv-stringify": {
+			"version": "6.4.4",
+			"resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.4.4.tgz",
+			"integrity": "sha512-NDshLupGa7gp4UG4sSNIqwYJqgSwvds0SvENntxoVoVvTzXcrHvd5gG2MWpbRpSNvk59dlmIe1IwNvSxN4IVmg=="
 		},
 		"node_modules/csvtojson": {
 			"version": "2.0.10",
@@ -20761,6 +20767,11 @@
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.2.tgz",
 			"integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==",
 			"dev": true
+		},
+		"csv-stringify": {
+			"version": "6.4.4",
+			"resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.4.4.tgz",
+			"integrity": "sha512-NDshLupGa7gp4UG4sSNIqwYJqgSwvds0SvENntxoVoVvTzXcrHvd5gG2MWpbRpSNvk59dlmIe1IwNvSxN4IVmg=="
 		},
 		"csvtojson": {
 			"version": "2.0.10",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 	},
 	"dependencies": {
 		"csvtojson": "^2.0.10",
+		"csv-stringify": "^6.4.0",
 		"tablemark": "^3.0.0"
 	},
 	"scripts": {

--- a/run.sh
+++ b/run.sh
@@ -12,6 +12,7 @@ NEW_VERSION=${2-trunk}
 SKIP_INIT=${3-false}
 OUTPUT=${4-markdown}
 SKIP_FORMATTING=${5-false}
+PRINT_TO_FILES=${6-false}
 
 # Configure WordPress versions
 
@@ -99,13 +100,29 @@ cd ./wpp-research || exit
 
 npm run research --silent -- benchmark-web-vitals -u http://localhost:8881/ -n 20 -p -o csv > before.csv
 npm run research --silent -- benchmark-web-vitals -u http://localhost:8891/ -n 20 -p -o csv > after.csv
-node ../scripts/results.js "Web Vitals (Block Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
+if [[ $PRINT_TO_FILES == 'true' ]]; then
+	if [[ $OUTPUT == 'csv' ]]; then
+		node ../scripts/results.js "Web Vitals (Block Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING > web-vitals-block-theme.csv
+	else
+		node ../scripts/results.js "Web Vitals (Block Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING > web-vitals-block-theme.md
+	fi
+else
+	node ../scripts/results.js "Web Vitals (Block Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
+fi
 
 # Benchmark Server-Timing
 
 npm run research --silent  -- benchmark-server-timing -u http://localhost:8881/ -n 100 -p -o csv > before.csv
 npm run research --silent  -- benchmark-server-timing -u http://localhost:8891/ -n 100 -p -o csv > after.csv
-node ../scripts/results.js "Server-Timing (Block Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
+if [[ $PRINT_TO_FILES == 'true' ]]; then
+	if [[ $OUTPUT == 'csv' ]]; then
+		node ../scripts/results.js "Server-Timing (Block Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING > server-timing-block-theme.csv
+	else
+		node ../scripts/results.js "Server-Timing (Block Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING > server-timing-block-theme.md
+	fi
+else
+	node ../scripts/results.js "Server-Timing (Block Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
+fi
 
 # Install classic theme
 
@@ -119,13 +136,29 @@ cd ./wpp-research || exit
 
 npm run research --silent -- benchmark-web-vitals -u http://localhost:8881/ -n 20 -p -o csv > before.csv
 npm run research --silent -- benchmark-web-vitals -u http://localhost:8891/ -n 20 -p -o csv > after.csv
-node ../scripts/results.js "Web Vitals (Classic Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
+if [[ $PRINT_TO_FILES == 'true' ]]; then
+	if [[ $OUTPUT == 'csv' ]]; then
+		node ../scripts/results.js "Web Vitals (Classic Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING > web-vitals-classic-theme.csv
+	else
+		node ../scripts/results.js "Web Vitals (Classic Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING > web-vitals-classic-theme.md
+	fi
+else
+	node ../scripts/results.js "Web Vitals (Classic Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
+fi
 
 # Benchmark Server-Timing
 
 npm run research --silent  -- benchmark-server-timing -u http://localhost:8881/ -n 100 -p -o csv > before.csv
 npm run research --silent  -- benchmark-server-timing -u http://localhost:8891/ -n 100 -p -o csv > after.csv
-node ../scripts/results.js "Server-Timing (Classic Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
+if [[ $PRINT_TO_FILES == 'true' ]]; then
+	if [[ $OUTPUT == 'csv' ]]; then
+		node ../scripts/results.js "Server-Timing (Classic Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING > server-timing-classic-theme.csv
+	else
+		node ../scripts/results.js "Server-Timing (Classic Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING > server-timing-classic-theme.md
+	fi
+else
+	node ../scripts/results.js "Server-Timing (Classic Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
+fi
 
 # Shutdown sites again
 

--- a/run.sh
+++ b/run.sh
@@ -10,6 +10,8 @@ fi
 OLD_VERSION=${1-latest}
 NEW_VERSION=${2-trunk}
 SKIP_INIT=${3-false}
+OUTPUT=${4-markdown}
+SKIP_FORMATTING=${5-false}
 
 # Configure WordPress versions
 
@@ -97,13 +99,13 @@ cd ./wpp-research || exit
 
 npm run research --silent -- benchmark-web-vitals -u http://localhost:8881/ -n 20 -p -o csv > before.csv
 npm run research --silent -- benchmark-web-vitals -u http://localhost:8891/ -n 20 -p -o csv > after.csv
-node ../scripts/results.js "Web Vitals (Block Theme)" before.csv after.csv
+node ../scripts/results.js "Web Vitals (Block Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
 
 # Benchmark Server-Timing
 
 npm run research --silent  -- benchmark-server-timing -u http://localhost:8881/ -n 100 -p -o csv > before.csv
 npm run research --silent  -- benchmark-server-timing -u http://localhost:8891/ -n 100 -p -o csv > after.csv
-node ../scripts/results.js "Server-Timing (Block Theme)" before.csv after.csv
+node ../scripts/results.js "Server-Timing (Block Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
 
 # Install classic theme
 
@@ -117,13 +119,13 @@ cd ./wpp-research || exit
 
 npm run research --silent -- benchmark-web-vitals -u http://localhost:8881/ -n 20 -p -o csv > before.csv
 npm run research --silent -- benchmark-web-vitals -u http://localhost:8891/ -n 20 -p -o csv > after.csv
-node ../scripts/results.js "Web Vitals (Classic Theme)" before.csv after.csv
+node ../scripts/results.js "Web Vitals (Classic Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
 
 # Benchmark Server-Timing
 
 npm run research --silent  -- benchmark-server-timing -u http://localhost:8881/ -n 100 -p -o csv > before.csv
 npm run research --silent  -- benchmark-server-timing -u http://localhost:8891/ -n 100 -p -o csv > after.csv
-node ../scripts/results.js "Server-Timing (Classic Theme)" before.csv after.csv
+node ../scripts/results.js "Server-Timing (Classic Theme)" before.csv after.csv $OUTPUT $SKIP_FORMATTING
 
 # Shutdown sites again
 


### PR DESCRIPTION
This PR comes with 3 related enhancements:
* Support for formatting as CSV, using the `csv-stringify` package (same approach as used in the WPP Research repo)
* Support for skipping the formatting of numeric values (e.g. print `105.73` instead of `"105.75 ms"`, or `0.2389111231231` instead of `"23.89%"`).
* Support for sending the output to files instead of displaying.
    * This will generate 4 files, one for each comparison.
    * The file names will be chosen depending on the output format, either using `.md` or `.csv` extension.

All 3 enhancements are optionally configurable, and the default behavior remains as it was before. The `README.md` has been updated with a few examples for the new arguments.