### PR TITLE
Use older Performance Lab version to support WP versions 6.1 and 6.2

### DIFF
--- a/new/.wp-env.json
+++ b/new/.wp-env.json
@@ -4,7 +4,7 @@
 	"testsPort": 8891,
 	"plugins": [
 		"https://downloads.wordpress.org/plugin/wordpress-importer.zip",
-		"https://downloads.wordpress.org/plugin/performance-lab.zip"
+		"https://downloads.wordpress.org/plugin/performance-lab.2.6.1.zip"
 	],
 	"themes": [
 		"https://downloads.wordpress.org/theme/twentytwentyone.zip",

--- a/old/.wp-env.json
+++ b/old/.wp-env.json
@@ -4,7 +4,7 @@
 	"testsPort": 8881,
 	"plugins": [
 		"https://downloads.wordpress.org/plugin/wordpress-importer.zip",
-		"https://downloads.wordpress.org/plugin/performance-lab.zip"
+		"https://downloads.wordpress.org/plugin/performance-lab.2.6.1.zip"
 	],
 	"themes": [
 		"https://downloads.wordpress.org/theme/twentytwentyone.zip",


### PR DESCRIPTION
This PR simply changes the Performance Lab version used to 2.6.1, in order to support WordPress versions 6.1 and 6.2, which are still recent and therefore commonly subject to benchmarking.

This is necessary because starting at Performance Lab 2.7.0, the minimum required WordPress version is 6.3.

Using this older version doesn't make a difference in the expected behavior, as all we're using from the plugin anyway is its Server-Timing capabilities.

In the future, we could consider making this version flexible, either via an optional workflow parameter, or via automatically choosing the PL version _if_ an older WordPress version is being tested. This would be more complex though (either from an end user or development perspective), so for now I am simply hard-coding the version that gives us the best support commonly needed.