### PR TITLE
Allow benchmarking with Memcached enabled

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,11 @@ on:
         - twentytwentythree
         - twentytwentyfour
         required: true
+      memcached:
+        description: 'Whether to test with memcached enabled'
+        type: 'boolean'
+        default: false
+        required: false
 
 jobs:
   benchmarks:
@@ -79,6 +84,8 @@ jobs:
           chmod -R 767 new/ # TODO: Possibly integrate in wp-env
           (cd old && wp-env start)
           (cd new && wp-env start)
+        env:
+          LOCAL_PHP_MEMCACHED: ${{ inputs.memcached }}
 
       - name: Update permalink structure
         run: |


### PR DESCRIPTION
This adds another (optional) workflow input for whether to enable Memcached for the comparisons.

This is about _any_ object cache. While Redis may be preferable today, Memcached is supported by `@wordpress/env` out of the box, so it makes sense to rely on that for now.

See related https://core.trac.wordpress.org/ticket/59900.