### PR TITLE
Update plugins and themes

### DIFF
--- a/new/.wp-env.json
+++ b/new/.wp-env.json
@@ -3,8 +3,8 @@
 	"port": 8890,
 	"testsPort": 8891,
 	"plugins": [
-		"https://downloads.wordpress.org/plugin/wordpress-importer.zip",
-		"https://downloads.wordpress.org/plugin/performance-lab.3.5.1.zip"
+		"https://downloads.wordpress.org/plugin/wordpress-importer.latest-stable.zip",
+		"https://downloads.wordpress.org/plugin/performance-lab.latest-stable.zip"
 	],
 	"themes": [
 		"https://downloads.wordpress.org/theme/twentytwentyone.zip",

--- a/new/.wp-env.json
+++ b/new/.wp-env.json
@@ -4,12 +4,12 @@
 	"testsPort": 8891,
 	"plugins": [
 		"https://downloads.wordpress.org/plugin/wordpress-importer.zip",
-		"https://downloads.wordpress.org/plugin/performance-lab.2.6.1.zip"
+		"https://downloads.wordpress.org/plugin/performance-lab.3.5.1.zip"
 	],
 	"themes": [
 		"https://downloads.wordpress.org/theme/twentytwentyone.zip",
 		"https://downloads.wordpress.org/theme/twentytwentythree.zip",
-		"WordPress/twentytwentyfour"
+		"https://downloads.wordpress.org/theme/twentytwentyfour.zip"
 	],
 	"mappings": {
 		"wp-cli.yml": "../shared/wp-cli.yml",

--- a/old/.wp-env.json
+++ b/old/.wp-env.json
@@ -4,12 +4,12 @@
 	"testsPort": 8881,
 	"plugins": [
 		"https://downloads.wordpress.org/plugin/wordpress-importer.zip",
-		"https://downloads.wordpress.org/plugin/performance-lab.2.6.1.zip"
+		"https://downloads.wordpress.org/plugin/performance-lab.3.5.1.zip"
 	],
 	"themes": [
 		"https://downloads.wordpress.org/theme/twentytwentyone.zip",
 		"https://downloads.wordpress.org/theme/twentytwentythree.zip",
-		"WordPress/twentytwentyfour"
+		"https://downloads.wordpress.org/theme/twentytwentyfour.zip"
 	],
 	"mappings": {
 		"wp-cli.yml": "../shared/wp-cli.yml",

--- a/old/.wp-env.json
+++ b/old/.wp-env.json
@@ -3,8 +3,8 @@
 	"port": 8880,
 	"testsPort": 8881,
 	"plugins": [
-		"https://downloads.wordpress.org/plugin/wordpress-importer.zip",
-		"https://downloads.wordpress.org/plugin/performance-lab.3.5.1.zip"
+		"https://downloads.wordpress.org/plugin/wordpress-importer.latest-stable.zip",
+		"https://downloads.wordpress.org/plugin/performance-lab.latest-stable.zip"
 	],
 	"themes": [
 		"https://downloads.wordpress.org/theme/twentytwentyone.zip",


### PR DESCRIPTION
These PR update the Performance Lab to it's latest version and use TT4 theme latest zip instead of archive Github repo theme.