### PR TITLE
Benchmarks: fix AI summary step failing on every run

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -38,8 +38,14 @@ on:
         default: 'en_US'
         required: false
 
+# `actions/ai-inference` v3 dropped the GitHub Models provider - which is being
+# sunset anyway - in favour of running the Copilot CLI, so `models: read` no
+# longer pays for anything. `copilot-requests: write` is what meters the
+# inference request now, and it is what lets the CLI authenticate as the
+# workflow instead of needing a personal access token in a secret.
 permissions:
-  models: read
+  contents: read
+  copilot-requests: write
 
 jobs:
   benchmarks:
@@ -186,15 +192,28 @@ jobs:
           NEW_VERSION: ${{ inputs.new == 'trunk' && 'master' || inputs.new }}
           TITLE: ${{ inputs.title }}
 
+      # The Copilot CLI is not preinstalled on GitHub-hosted runners, and
+      # `actions/ai-inference` v3 only shells out to it - it never installs it.
       - name: Install Copilot CLI
         run: npm install -g @github/copilot
 
+      # The summary is a nice-to-have on top of a benchmark run that takes the
+      # better part of an hour, so a flaky or unavailable model must not throw
+      # those results away. The step below reads `outcome`, not `response`.
       - name: AI Summary for Non-Technical Users
         id: ai-summary
+        continue-on-error: true
         env:
-          COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+          # No PAT secret needed: the CLI authenticates as the workflow, and
+          # `copilot-requests: write` meters the request to the repository owner.
+          GITHUB_TOKEN: ${{ github.token }}
         uses: actions/ai-inference@v3
         with:
+          # `actions/ai-inference` defaults this to `gpt-4.1`, which Copilot no
+          # longer offers - the CLI rejects it outright and the step fails on
+          # every run. `auto` lets Copilot pick, so a model being retired
+          # cannot break this again.
+          model: auto
           prompt: |
             Please analyze the following WordPress performance benchmark results and provide a clear, easy-to-understand summary for non-technical users.
 
@@ -222,10 +241,18 @@ jobs:
             Use simple language without technical jargon. If a metric shows improvement, clearly state that. If it shows regression, explain that too. Keep it concise.
 
       - name: Add AI summary to step summary
+        if: steps.ai-summary.outcome == 'success' && steps.ai-summary.outputs.response != ''
+        env:
+          # Passed as an environment variable rather than interpolated into the
+          # script: this is model output, and `${{ }}` would paste it into the
+          # shell verbatim, where a backtick or `$(...)` in the response runs.
+          AI_SUMMARY: ${{ steps.ai-summary.outputs.response }}
         run: |
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "---" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "## 🤖 AI Summary for Non-Technical Users" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "${{ steps.ai-summary.outputs.response }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo ""
+            echo "---"
+            echo ""
+            echo "## 🤖 AI Summary for Non-Technical Users"
+            echo ""
+            echo "$AI_SUMMARY"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
actions/ai-inference v3 defaults its model to gpt-4.1, which Copilot no
longer offers, so the CLI rejects the request and the step exits 1 on
every run. Set model: auto and let Copilot pick, so a model being retired
cannot break this again.

Two related changes while here, following the setup in wp-cli/.github:

- Authenticate the Copilot CLI as the workflow via github.token plus
  copilot-requests: write, instead of a COPILOT_GITHUB_TOKEN secret. v3
  dropped the GitHub Models provider, so the old models: read permission
  no longer pays for anything, and no personal access token is needed.
- Do not throw away an hour of benchmark results when the summary fails:
  the inference step is continue-on-error, and the step that appends the
  summary is guarded on its outcome. That step now passes the response
  through the environment rather than interpolating model output straight
  into the shell.

Fixes #184

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QefmvWRo7xjySpDuuJXFSC